### PR TITLE
Put posts in /blog/

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -270,6 +270,7 @@ defaults:
       layout: "post"
       comments: true  # add comments to all blog posts
       social-share: true # add social media sharing buttons to all blog posts
+      permalink: /blog/:title/
   -
     scope:
       path: "" # any file that's not a post will be a "page" layout by default

--- a/_posts/2022-08-22-adult-adhd-resources-diagnosis.md
+++ b/_posts/2022-08-22-adult-adhd-resources-diagnosis.md
@@ -1,11 +1,9 @@
 ---
-layout: post
 title: So You Think You Have ADHD? (Adult) ADHD
 subtitle: Resources to Get You Started
 thumbnail-img: /assets/img/blog/pexels-vlada-karpovich-7365454.jpg
 share-img: /assets/img/blog/pexels-vlada-karpovich-7365454.jpg
 author: Kai Katschthaler
-permalink: adult-adhd-resources-diagnosis
 ---
 
 First off, the disclaimer: IANAD (I am not a doctor), so none of this is medical advice or can replace medical advice. What this is, hopefully, is a way to help you get started with looking things up and figuring out whether you might want to seek a diagnosis or not.


### PR DESCRIPTION
This seems to do the trick: leave default permalink as is, remove post's permalink override, change permalink for posts to include the `/blog/` prefix (you can just literally put it there)